### PR TITLE
Allow datasets without an AVRO schema

### DIFF
--- a/intake_dal/tests/catalog.yaml
+++ b/intake_dal/tests/catalog.yaml
@@ -36,4 +36,11 @@ entity:
           write_delay_between_chunks_milliseconds: 50
           write_chunk_size: 10
           write_parallelism: 2
-
+dataset_without_avro:
+  driver: dal
+  args:
+    storage:
+      batch:
+        url: 'parquet://{{ CATALOG_DIR }}/data/user_events.parquet'
+        args:
+          engine: 'fastparquet'

--- a/intake_dal/tests/test_dal_source.py
+++ b/intake_dal/tests/test_dal_source.py
@@ -40,6 +40,18 @@ def test_canonical_name(serving_cat):
     assert ds.discover()["metadata"]["canonical_name"] == "entity.user.user_events"
 
 
+def test_dataset_without_avro_and_engine_arg(serving_cat):
+    """Tests an entry in the catalog without an AVRO, and tests engine arg"""
+    ds: DalSource = serving_cat.dataset_without_avro(storage_mode="batch")
+
+    # force the DalSource to instantiate the private source object
+    ds.discover()
+
+    # ensure that the engine argument is passed along to the DalSource instantiated source object
+    assert ds.source._captured_init_kwargs['engine'] == 'fastparquet'
+    assert not ds.source._captured_init_kwargs['gather_statistics']
+
+
 def test_parse_storage_mode_url():
     def validate_url(url: str, expected: str):
         assert DalSource.parse_storage_mode_url(url) == (urlparse(url), expected)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "intake-dal"
-version = "0.1.4"
+version = "0.1.5"
 description = "Intake single YAML hierarchical catalog."
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
Also validates that the passed in engine is passed in correctly.