### PR TITLE
[AIP-885] Enable multi-key read

### DIFF
--- a/intake_dal/dal_online.py
+++ b/intake_dal/dal_online.py
@@ -2,6 +2,7 @@ import base64
 import io
 import time
 import urllib.parse
+from collections import Iterable
 from datetime import datetime
 from http import HTTPStatus
 from typing import Callable, Dict, List, Tuple
@@ -74,13 +75,16 @@ class DalOnlineSource(DataSource):
         )
 
     def _get_partition(self, _) -> pd.DataFrame:
-        self._get_schema()
-        if isinstance(self._key_value, list):
-            massaged_key = ",".join(map(str, self._key_value))
-        else:
-            massaged_key = self._key_value
 
-        data = _http_get_avro_data_set(self._url, self._canonical_name, massaged_key)
+        def http_get_argument():
+            if isinstance(self._key_value, Iterable):
+                return ",".join(map(str, self._key_value))
+            else:
+                return self._key_value
+
+        self._get_schema()
+
+        data = _http_get_avro_data_set(self._url, self._canonical_name, http_get_argument())
         for row in data:
             for key, field in row.items():
                 if isinstance(field, dict) and "format" in field:

--- a/intake_dal/dal_online.py
+++ b/intake_dal/dal_online.py
@@ -75,7 +75,12 @@ class DalOnlineSource(DataSource):
 
     def _get_partition(self, _) -> pd.DataFrame:
         self._get_schema()
-        data = _http_get_avro_data_set(self._url, self._canonical_name, self._key_value)
+        if isinstance(self._key_value, list):
+            massaged_key = ",".join(map(str, self._key_value))
+        else:
+            massaged_key = self._key_value
+
+        data = _http_get_avro_data_set(self._url, self._canonical_name, massaged_key)
         for row in data:
             for key, field in row.items():
                 if isinstance(field, dict) and "format" in field:

--- a/intake_dal/tests/test_dal_online.py
+++ b/intake_dal/tests/test_dal_online.py
@@ -107,3 +107,16 @@ def test_post_in_chunks(mock_put: MagicMock, serving_cat: DalCatalog, user_event
 
     assert len(mock_put.call_args_list) == 2
     assert len(ret) == 2
+
+
+@mock.patch("intake_dal.dal_online._http_get_avro_data_set")
+def test_dal_online_multi_key_read(
+    mock_get: MagicMock,
+    serving_cat: DalCatalog,
+    user_events_df: pd.DataFrame,
+    user_events_json: List[Dict],
+):
+    mock_get.return_value = user_events_json
+
+    assert_frame_equal(user_events_df, serving_cat.entity.user.user_events(key=[100, 101]).read(), check_dtype=False)
+    mock_get.assert_called()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "intake-dal"
-version = "0.1.6"
+version = "0.1.7"
 description = "Intake single YAML hierarchical catalog."
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
Closes [AIP-885] 

Allow multi-key reads as in 

```
cat.entity.property.dataset(key=[62994016, 33881021, 629940]).read())
```