### PR TITLE
Pass catalog object

### DIFF
--- a/intake_dal/dal_catalog.py
+++ b/intake_dal/dal_catalog.py
@@ -27,8 +27,8 @@ class DalCatalog(NestedYAMLFileCatalog):
         path: str
             Location of the file to parse (can be remote)
         catalog_data: dict
-            If catalog data is in memory, pass it thru `catalog_data` to populate intake catalog.
-            If dataset/catalog is in the local or a specific url is given, please use `path` argument.
+            If catalog data is in memory, pass it through `catalog_data` to populate the intake catalog.
+            If the dataset/catalog is in the local or a specific url is given, please use the `path` argument.
         reload: bool
             Whether to watch the source file for changes; make False if you want
             an editable Catalog

--- a/intake_dal/tests/conftest.py
+++ b/intake_dal/tests/conftest.py
@@ -11,6 +11,11 @@ def catalog_path():
 
 
 @pytest.fixture
+def remote_catalog_path():
+    return str(Path(__file__).resolve().parent.joinpath(Path("remote_storage_catalog.yaml")))
+
+
+@pytest.fixture
 def serving_cat(catalog_path: str):
     return DalCatalog(catalog_path, storage_mode="serving")
 

--- a/intake_dal/tests/remote_storage_catalog.yaml
+++ b/intake_dal/tests/remote_storage_catalog.yaml
@@ -1,0 +1,27 @@
+name: My Sample Catalog
+metadata:
+  hierarchical_catalog: true
+entity:
+  property:
+    user_event:
+      args:
+        default: batch
+        storage:
+          batch: parquet://https://my_storage.com/user_event/date={{date}}/*.parquet
+          golden: parquet://https://my_storage.com/user_event/golden/date={{date}}/*.parquet
+      description: This is user_event description
+      driver: dal
+      metadata:
+        owner_team: my-team
+        public: false
+    user_dataset:
+      args:
+        default: batch
+        storage:
+          batch: parquet://https://my_storage.com/user_dataset/date={{date}}/*.parquet
+          serving: dal-online://https://featurestore.url.net#userid
+      description: This is user_dataset description
+      driver: dal
+      metadata:
+        owner_team: my-team
+        public: false

--- a/intake_dal/tests/test_dal_catalog.py
+++ b/intake_dal/tests/test_dal_catalog.py
@@ -1,5 +1,5 @@
+import yaml
 import pandas as pd
-
 from intake_dal.dal_catalog import DalCatalog
 
 
@@ -69,3 +69,17 @@ def test_construct_dataset(cat):
     validate_dataset(cat["entity.user.user_events"])
     validate_dataset(cat.entity["user.user_events"])
     validate_dataset(cat.entity.user["user_events"])
+
+
+def test_dal_catalog_passing_dict(remote_catalog_path):
+    with open(remote_catalog_path, 'r') as f:
+        data = yaml.load(f)
+
+    # Instead of passing path, passes the catalog data read from the file.
+    cat = DalCatalog(catalog_data=data, storage_mode="golden")
+
+    assert cat.entity.property.user_event.default == "golden"
+    assert cat.entity.property.user_dataset.default == "golden"
+
+    assert len(cat.entity.property.user_event.storage) == 2
+    assert len(cat.entity.property.user_dataset.storage) == 2


### PR DESCRIPTION
When intake catalog is populated, the local catalog file `path` is received as an argument. This PR populates the Intake catalog by using the catalog object in `memory`, not the catalog file path.